### PR TITLE
Fix mobile layout, image loading, and horizontal scroll

### DIFF
--- a/src/Components/LazyImage.jsx
+++ b/src/Components/LazyImage.jsx
@@ -1,9 +1,17 @@
 import React, { useState, useRef, useEffect } from 'react';
 
+const getLowResSrc = (src) => {
+    if (!src?.includes('res.cloudinary.com')) return null;
+    // 800px wide at quality 10 — large enough to fill max-width:350px containers
+    // but fast to download (~20-40KB vs 100-500KB for full-res)
+    return src.replace('f_auto,q_auto', 'w_800,q_10,f_auto');
+};
+
 const LazyImage = ({ src, alt, style, className, onClick, ...props }) => {
-    const [isLoaded, setIsLoaded] = useState(false);
     const [isInView, setIsInView] = useState(false);
+    const [isHighResLoaded, setIsHighResLoaded] = useState(false);
     const imgRef = useRef();
+    const lowResSrc = getLowResSrc(src);
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -13,49 +21,65 @@ const LazyImage = ({ src, alt, style, className, onClick, ...props }) => {
                     observer.disconnect();
                 }
             },
-            {
-                threshold: 0.1,
-                rootMargin: '50px'
-            }
+            { threshold: 0.1, rootMargin: '50px' }
         );
-
-        if (imgRef.current) {
-            observer.observe(imgRef.current);
-        }
-
+        if (imgRef.current) observer.observe(imgRef.current);
         return () => observer.disconnect();
     }, []);
 
-    const handleLoad = () => {
-        setIsLoaded(true);
-    };
-
     return (
-        <div ref={imgRef} style={style} className={className}>
-            {isInView && (
+        <div ref={imgRef} className={className} style={style} onClick={onClick}>
+            {!isInView && (
+                <div style={{
+                    width: '100%',
+                    height: '200px',
+                    background: 'linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%)',
+                    backgroundSize: '200% 100%',
+                    animation: 'shimmer 1.5s infinite',
+                }} />
+            )}
+            {isInView && lowResSrc && (
+                <div style={{ position: 'relative', overflow: 'hidden' }}>
+                    {/* Low-res in normal flow — provides layout dimensions (same max-width as high-res) */}
+                    <img
+                        src={lowResSrc}
+                        alt=""
+                        aria-hidden="true"
+                        style={{
+                            display: 'block',
+                            filter: 'blur(8px)',
+                            transform: 'scale(1.03)',
+                        }}
+                    />
+                    {/* High-res overlay — fades in when loaded */}
+                    <img
+                        src={src}
+                        alt={alt}
+                        onLoad={() => setIsHighResLoaded(true)}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            height: '100%',
+                            display: 'block',
+                            opacity: isHighResLoaded ? 1 : 0,
+                            transition: 'opacity 0.5s ease-in-out',
+                        }}
+                        {...props}
+                    />
+                </div>
+            )}
+            {isInView && !lowResSrc && (
                 <img
                     src={src}
                     alt={alt}
-                    onLoad={handleLoad}
-                    onClick={onClick}
+                    onLoad={() => setIsHighResLoaded(true)}
                     style={{
-                        opacity: isLoaded ? 1 : 0,
-                        transition: 'opacity 0.3s ease-in-out',
-                        ...style
+                        opacity: isHighResLoaded ? 1 : 0,
+                        transition: 'opacity 0.5s ease-in-out',
                     }}
                     {...props}
-                />
-            )}
-            {!isLoaded && isInView && (
-                <div
-                    style={{
-                        width: '100%',
-                        height: '200px',
-                        backgroundColor: '#e0e0e0',
-                        background: 'linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%)',
-                        backgroundSize: '200% 100%',
-                        animation: 'shimmer 1.5s infinite',
-                    }}
                 />
             )}
         </div>

--- a/src/Components/Navbar.css
+++ b/src/Components/Navbar.css
@@ -77,6 +77,7 @@
     right: 7;
     height: 7vh;
     width: 98vw;
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/Components/NewsBlock.css
+++ b/src/Components/NewsBlock.css
@@ -70,4 +70,41 @@
     width: 100%;
     text-align: right;
   }
-  
+
+@media only screen and (max-width: 850px) {
+    .main-news-block {
+        flex-direction: column;
+        align-items: center;
+        padding: 20px 15px 30px;
+        margin-top: 20px;
+    }
+
+    .normal-news-block,
+    .reverse-news-block {
+        flex-direction: column;
+    }
+
+    .normal-picture-block,
+    .reverse-picture-block {
+        margin: 0 0 15px 0;
+        width: 100%;
+    }
+
+    .picture-news-block img {
+        max-width: 100%;
+        width: 100%;
+        padding: 0;
+    }
+
+    .content-news-block {
+        width: 100%;
+    }
+
+    .reverse-text-block p {
+        text-align: left;
+    }
+
+    .reverse-title-block {
+        justify-content: flex-start;
+    }
+}

--- a/src/Components/Page.css
+++ b/src/Components/Page.css
@@ -6,13 +6,13 @@
     margin: 0;
     padding: 0;
     max-width: 100%;
+    overflow-x: hidden;
 }
 
 
 .page-background {
     width: 100vw;
     height: 100vh;
-    min-width: 400px;
     background-repeat: no-repeat;
     background-attachment: fixed;
 }
@@ -27,6 +27,7 @@
     flex-direction: column;
     width: 100%;
     color: black;
+    overflow-x: hidden;
 }
 
 .page-written {
@@ -87,6 +88,7 @@
     color: black;
     padding-top: 60px;
     padding-bottom: 60px;
+    overflow-x: hidden;
     background: linear-gradient(
         to right,
         #f7f5f2 0%,
@@ -107,6 +109,7 @@
     justify-content: center;
     align-items: center;
     flex-direction: column;
+    overflow-x: hidden;
 }
 
 .page-footer {
@@ -119,21 +122,22 @@
 
 /* mobile view */
 
-@media only screen and (max-width: 450px) {
-
+@media only screen and (max-width: 850px) {
 
     .page-written {
         flex-direction: column;
     }
 
     .page-right {
-        width: 80%;
-        padding: 0 30px;
+        width: 100%;
+        padding: 0 20px;
+        box-sizing: border-box;
     }
 
     .page-left {
-        width: 80%;
-        padding: 0 30px;
+        width: 100%;
+        padding: 0 20px;
+        box-sizing: border-box;
     }
 
     .page-content-no-bg {

--- a/src/Components/PictureGrid.css
+++ b/src/Components/PictureGrid.css
@@ -38,3 +38,11 @@
     font-weight: 100;
     color: white;
 }
+
+@media only screen and (max-width: 850px) {
+    .grid-box {
+        width: calc(100vw - 48px);
+        height: calc((100vw - 48px) * 0.75);
+        max-width: 400px;
+    }
+}

--- a/src/Styles/Contact.css
+++ b/src/Styles/Contact.css
@@ -10,13 +10,12 @@
 }
 
 
+
 .contact-background {
     width: 100vw;
     height: 100vh;
-    min-width: 500px;
     background-repeat: no-repeat;
     background-attachment: fixed;
-
 }
 
 .contact-content {

--- a/src/Styles/Home.css
+++ b/src/Styles/Home.css
@@ -6,12 +6,12 @@
     margin: 0;
     padding: 0;
     max-width: 100%;
+    overflow-x: hidden;
 }
 
 .home-background {
     width: 100vw;
     height: 100vh;
-    min-width: 400px;
     background-repeat: no-repeat;
     background-attachment: fixed;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@ body {
 html, body {
   max-width: 100%;
   overflow-x: hidden;
+  overscroll-behavior-x: none;
 }
 
 code {


### PR DESCRIPTION
- Stack NewsBlock content vertically on mobile (850px breakpoint)
- Progressive image loading: low-res Cloudinary placeholder fades to high-res
- Fix horizontal wiggle by removing min-width floors, adding overflow-x:hidden to page content containers, box-sizing:border-box on navbar-mobile, and overscroll-behavior-x:none globally
- Update Page.css mobile breakpoint from 450px to 850px
- Scale PictureGrid boxes responsively on mobile